### PR TITLE
파이썬 requirements 파일 추가 및 Socket.IO 버전 변경

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+Flask
+flask_socketio
+natsort
+pillow
+opencv-python
+joblib
+pandas
+mediapipe
+tensorflow
+scikit-learn
+openpyxl

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,7 +5,7 @@
     <title>Document</title>
     <link href="{{url_for('static', filename = 'style.css')}}" rel="stylesheet">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-    <script src='https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.0.0/socket.io.js'></script>
+    <script src='https://cdnjs.cloudflare.com/ajax/libs/socket.io/3.0.4/socket.io.js'></script>
     <script src = "{{ url_for('static', filename = 'face-api.min.js') }}"></script> 
 </head>
 <body>


### PR DESCRIPTION
소스 코드를 이용해보려고 하는데, requirements 파일이 없어서 매번 일일히 설치하기가 힘들어서 추가해보았습니다.

다음의 명령어로 패키지를 한 번에 설치할 수 있습니다.

``` bash
pip install -r requirements.txt
```

추가로 flask socket.io와 javascript socket.io 버전이 호환되지 않아 javascript socket.io 버전을 변경했습니다.